### PR TITLE
Fix migration issues with nested stow symlinks and socket warnings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,13 @@ cmd_install() {
   install_copies
   create_vim_dirs
   run_post_update
+
+  if [[ "$SKIP_COUNT" -gt 0 ]]; then
+    warn "$SKIP_COUNT file(s) skipped (rerun with --force to override)"
+    header "Install incomplete"
+    exit 1
+  fi
+
   header "Install complete!"
 }
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -192,7 +192,8 @@ check_stale_stow_links() {
   done
 
   # Also check for nested stow symlinks inside managed directories
-  for dir in "$HOME/.config" "$HOME/.vim"; do
+  for entry in "${STOW_DIRS[@]}"; do
+    local dir="$HOME/${entry%%:*}"
     if [[ ! -d "$dir" ]]; then
       continue
     fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -191,6 +191,22 @@ check_stale_stow_links() {
     fi
   done
 
+  # Also check for nested stow symlinks inside managed directories
+  for dir in "$HOME/.config" "$HOME/.vim"; do
+    if [[ ! -d "$dir" ]]; then
+      continue
+    fi
+    while IFS= read -r link; do
+      local link_dest
+      link_dest="$(readlink "$link")"
+      if [[ "$link_dest" == *"/stow/dot-"* || "$link_dest" == *".dotfiles/stow/"* ]]; then
+        local rel="${link#"$HOME/"}"
+        problem "Stale stow symlink: ~/$rel → $link_dest (run scripts/migrate.sh)"
+        ((stale++)) || true
+      fi
+    done < <(find "$dir" -type l 2>/dev/null)
+  done
+
   if [[ "$stale" -eq 0 ]]; then
     ok "No stale stow symlinks found"
   fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -36,6 +36,13 @@ STOW_DOTFILES=(
   .vimrc_background
   .zshrc
 )
+# Directories that were symlinked wholesale by stow (e.g. ~/.config → stow/dot-config).
+# Used by migrate.sh (to convert + clean up) and doctor.sh (to detect stale nested links).
+# Format: "dotfile_name:stow_package_name"
+STOW_DIRS=(
+  ".config:dot-config"
+  ".vim:dot-vim"
+)
 DOTFILES_HOME="$DOTFILES_ROOT/home"
 DOTFILES_COPY="$DOTFILES_ROOT/copy"
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 DRY_RUN="${DRY_RUN:-0}"
 FORCE="${FORCE:-0}"
 QUIET="${QUIET:-0}"
+SKIP_COUNT="${SKIP_COUNT:-0}"
 
 DOTFILES_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
@@ -101,6 +102,42 @@ ensure_parent_dir() {
   fi
 }
 
+# --- Copy helpers ---
+# Copy a file/directory tree, skipping socket files (e.g. git fsmonitor IPC).
+copy_preserved_item() {
+  local src="$1"
+  local dest="$2"
+
+  # Skip bare sockets
+  if [[ -S "$src" ]]; then
+    return 0
+  fi
+
+  # For directories, walk the tree manually so we can skip sockets inside
+  if [[ -d "$src" && ! -L "$src" ]]; then
+    run mkdir -p "$dest"
+
+    while IFS= read -r -d '' path; do
+      local rel="${path#"$src"/}"
+      local out="$dest/$rel"
+
+      if [[ -S "$path" ]]; then
+        continue
+      elif [[ -d "$path" && ! -L "$path" ]]; then
+        run mkdir -p "$out"
+      else
+        ensure_parent_dir "$out"
+        run cp -P "$path" "$out"
+      fi
+    done < <(find "$src" -mindepth 1 -print0)
+
+    return 0
+  fi
+
+  # Plain files / symlinks
+  run cp -P "$src" "$dest"
+}
+
 # --- Symlink operations ---
 link_one() {
   local src="$1" target="$2"
@@ -128,7 +165,8 @@ link_one() {
       info "Linking $target → $src"
       run ln -s "$src" "$target"
     else
-      warn "Skipping $target (exists and is not a symlink; use --force to override)"
+      warn "Skipping $target (exists and is not a symlink ; use --force to override)"
+      ((SKIP_COUNT++)) || true
     fi
     return 0
   fi

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -287,24 +287,24 @@ main() {
     log "Running in dry-run mode — no changes will be made"
   fi
 
-  # Step 1: Handle directory symlinks (preserve untracked files)
-  migrate_stow_dir ".config" "dot-config"
-  migrate_stow_dir ".vim" "dot-vim"
+  # Step 1: Handle directory symlinks and clean up nested stow symlinks
+  for entry in "${STOW_DIRS[@]}"; do
+    local dotfile="${entry%%:*}"
+    local stow_name="${entry##*:}"
+    migrate_stow_dir "$dotfile" "$stow_name"
+    remove_stow_symlinks_under "$HOME/$dotfile"
+  done
 
-  # Step 2: Remove nested stow symlinks inside migrated directories
-  remove_stow_symlinks_under "$HOME/.config"
-  remove_stow_symlinks_under "$HOME/.vim"
-
-  # Step 3: Remove all other stow symlinks
+  # Step 2: Remove all other stow symlinks
   remove_stow_symlinks
 
-  # Step 4: Remove old base16-shell (replaced by tinted-shell)
+  # Step 3: Remove old base16-shell (replaced by tinted-shell)
   cleanup_base16
 
-  # Step 5: Remove oh-my-zsh (replaced by lightweight starship+shared shell config)
+  # Step 4: Remove oh-my-zsh (replaced by lightweight starship+shared shell config)
   cleanup_oh_my_zsh
 
-  # Step 6: Check for files that will block install.sh
+  # Step 5: Check for files that will block install.sh
   prepare_managed_targets
 
   header "Migration complete!"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -92,10 +92,29 @@ migrate_stow_dir() {
       continue
     fi
     info "Preserving untracked: ~/$dotfile/$name"
-    run cp -R "$item" "$dest"
+    copy_preserved_item "$item" "$dest"
   done
 
   log "~/$dotfile migration complete"
+}
+
+remove_stow_symlinks_under() {
+  local root="$1"
+  [[ -d "$root" ]] || return 0
+
+  local removed=0
+  while IFS= read -r link; do
+    if is_stow_symlink "$link"; then
+      local rel="${link#"$HOME/"}"
+      info "Removing nested stow symlink: ~/$rel → $(readlink "$link")"
+      run rm "$link"
+      ((removed++)) || true
+    fi
+  done < <(find "$root" -type l 2>/dev/null)
+
+  if [[ "$removed" -gt 0 ]]; then
+    log "Removed $removed nested stow symlink(s) under $root"
+  fi
 }
 
 remove_stow_symlinks() {
@@ -127,6 +146,55 @@ remove_stow_symlinks() {
   done
 
   log "Removed $removed stow symlink(s), skipped $skipped"
+}
+
+prepare_managed_targets() {
+  header "Checking for install blockers"
+
+  local blocked=0
+
+  while IFS= read -r rel; do
+    local src="$DOTFILES_HOME/$rel"
+    local target="$HOME/$rel"
+
+    # Only check file entries (install.sh only links non-directories)
+    if [[ -d "$src" && ! -L "$src" ]]; then
+      continue
+    fi
+
+    if [[ -L "$target" ]]; then
+      local current
+      current="$(readlink "$target")"
+      if [[ "$current" == "$src" ]]; then
+        continue
+      fi
+      if is_stow_symlink "$target"; then
+        info "Removing stale stow symlink: ~/$rel → $current"
+        run rm "$target"
+      elif [[ "$FORCE" -eq 1 ]]; then
+        backup_path "$target"
+      else
+        warn "~/$rel exists as symlink → $current (rerun with --force to override)"
+        ((blocked++)) || true
+      fi
+      continue
+    fi
+
+    if [[ -e "$target" ]]; then
+      if [[ "$FORCE" -eq 1 ]]; then
+        backup_path "$target"
+      else
+        warn "~/$rel exists and is not a symlink (rerun with --force to override)"
+        ((blocked++)) || true
+      fi
+    fi
+  done < <(cd "$DOTFILES_HOME" && find . -mindepth 1 | sed 's|^\./||' | sort)
+
+  if [[ "$blocked" -gt 0 ]]; then
+    warn "$blocked managed path(s) will block install; rerun migrate.sh --force to back them up"
+  else
+    log "No install blockers found"
+  fi
 }
 
 cleanup_base16() {
@@ -223,14 +291,21 @@ main() {
   migrate_stow_dir ".config" "dot-config"
   migrate_stow_dir ".vim" "dot-vim"
 
-  # Step 2: Remove all other stow symlinks
+  # Step 2: Remove nested stow symlinks inside migrated directories
+  remove_stow_symlinks_under "$HOME/.config"
+  remove_stow_symlinks_under "$HOME/.vim"
+
+  # Step 3: Remove all other stow symlinks
   remove_stow_symlinks
 
-  # Step 3: Remove old base16-shell (replaced by tinted-shell)
+  # Step 4: Remove old base16-shell (replaced by tinted-shell)
   cleanup_base16
 
-  # Step 4: Remove oh-my-zsh (replaced by lightweight starship+shared shell config)
+  # Step 5: Remove oh-my-zsh (replaced by lightweight starship+shared shell config)
   cleanup_oh_my_zsh
+
+  # Step 6: Check for files that will block install.sh
+  prepare_managed_targets
 
   header "Migration complete!"
   log ""


### PR DESCRIPTION
Resolves #6

## Changes

### 1. Nested stow symlinks not cleaned up (`~/.config`)
- **`remove_stow_symlinks_under()`** (migrate.sh): Recursively finds and removes stow symlinks inside migrated directories like `~/.config` and `~/.vim`. Previously, only top-level entries in `STOW_DOTFILES` were cleaned.
- **`prepare_managed_targets()`** (migrate.sh): Walks the managed `home/` tree and identifies existing files that will block `install.sh`. Warns by default; with `--force`, backs them up using `backup_path()`.
- **doctor.sh**: Now also scans inside `~/.config` and `~/.vim` for stale stow symlinks.

### 2. Socket warnings during vim migration
- **`copy_preserved_item()`** (lib.sh): New helper that copies a file/directory tree while silently skipping socket files (e.g. `.git/fsmonitor--daemon.ipc`). Replaces bare `cp -R` in `migrate_stow_dir()`.

### 3. install.sh exit code
- `install.sh` now tracks skipped files via `SKIP_COUNT` and exits non-zero when symlinks couldn't be created, so "install complete" actually means complete.