### PR TITLE
Convert .gitconfig to symlink with local include support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ Thumbs.db
 ######
 *.swp
 .*.swp
+
+# Temporary docs #
+###################
+docs/superpowers/

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -1,6 +1,3 @@
-# LOCAL CONFIG
-
-# DO NOT EDIT BELOW THIS LINE
 [user]
 	name = Brian Sinclair
 	email = brianarn@gmail.com
@@ -64,3 +61,6 @@
 	track = !sh -c 'git branch --track "$0" "origin/$0" && git checkout "$0"'
 	whatis = show -s --pretty='tformat:%h (%s, %ad)' --date=short
 	cleanup-branches = !sh -c 'git branch --merged | grep -v ^* | xargs -n 1 git branch -d'
+
+[include]
+	path = ~/.gitconfig-local

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,6 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/scripts/lib.sh"
 source "$SCRIPT_DIR/scripts/post-update.sh"
 
-CUTSTRING="DO NOT EDIT BELOW THIS LINE"
-
 usage() {
   cat <<EOF
 Usage: ./install.sh [options] [command]
@@ -44,7 +42,6 @@ install_links() {
 
 install_copies() {
   header "Installing copied files"
-  merge_cutstring "$DOTFILES_COPY/gitconfig" "$HOME/.gitconfig" "$CUTSTRING"
   copy_if_missing "$DOTFILES_COPY/vimrc.local" "$HOME/.vimrc.local"
   copy_if_missing "$DOTFILES_COPY/vimplug.local" "$HOME/.vimplug.local"
   log "Copied files installed"


### PR DESCRIPTION
## Summary

- Moves `copy/gitconfig` → `home/.gitconfig` so it's symlinked like all other dotfiles (no more cutstring merge)
- Adds `[include] path = ~/.gitconfig-local` at the bottom, enabling dotfiles-private to provide machine-specific config (e.g., path-based identity overrides via `includeIf`)
- Removes the `CUTSTRING` variable and `merge_cutstring` call from `install.sh`
- Adds `docs/superpowers/` to `.gitignore`

Git silently skips the include if `~/.gitconfig-local` doesn't exist, so this is safe on machines without dotfiles-private.

## Migration

Run `./install.sh --force` — the existing `~/.gitconfig` (regular file) will be backed up and replaced with a symlink. Any hand-edits above the old cutstring should be moved to `~/.gitconfig-local`.

## Test plan

- [ ] Verify `./install.sh --force` symlinks `~/.gitconfig` correctly
- [ ] Verify `git config user.email` returns `brianarn@gmail.com` (default)
- [ ] After installing dotfiles-private assured profile, verify `git config user.email` returns `brian.sinclair@assured.claims` under `~/code/assured/`
- [ ] Verify `~/.gitconfig-local` not existing causes no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)