### PR TITLE
Fix extkeys terminal-features and add kitty support

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -20,7 +20,9 @@ set-option -as terminal-features ',xterm-256color:RGB,screen-256color:RGB,tmux-2
 # Extended key sequences (CSI u) — forwards Shift+Enter etc. to apps
 set-option -g extended-keys always
 set-option -s extended-keys-format csi-u
-set-option -as terminal-features ',xterm-256color:extkeys,tmux-256color:extkeys'
+set-option -as terminal-features 'xterm-256color:extkeys'
+set-option -as terminal-features 'tmux-256color:extkeys'
+set-option -as terminal-features 'xterm-kitty:extkeys'
 
 # Keep a lot of scrollback buffer
 set-option -g history-limit 50000


### PR DESCRIPTION
## Summary

- Split combined `terminal-features` extkeys line into individual entries (the combined form with comma-separated values may not parse correctly)
- Add `xterm-kitty:extkeys` for kitty terminal support

## Test plan

- [ ] Verify extended keys (e.g., Shift+Enter) work in tmux under xterm-256color
- [ ] Verify extended keys work under kitty

🤖 Generated with [Claude Code](https://claude.com/claude-code)